### PR TITLE
#129 hotfix(UserEcoRecordResDto): Age의 value를 반환하도록 수정

### DIFF
--- a/backend/src/main/java/com/kaspi/backend/dto/UserEcoRecordResDto.java
+++ b/backend/src/main/java/com/kaspi/backend/dto/UserEcoRecordResDto.java
@@ -13,7 +13,7 @@ import lombok.Data;
 public class UserEcoRecordResDto {
     private String userId;
     private Gender gender;
-    private Age age;
+    private String age;
     private long refuelingPrice;
     private long myEcoPrice;
     private long averageEcoPrice;

--- a/backend/src/main/java/com/kaspi/backend/service/UserRecordService.java
+++ b/backend/src/main/java/com/kaspi/backend/service/UserRecordService.java
@@ -86,7 +86,7 @@ public class UserRecordService {
                 .orElseThrow(() -> new SqlNotFoundException(ErrorCode.NOT_FOUND_FOOD_IMAGE));
 
         return UserEcoRecordResDto.builder().userId(user.getId())
-                .gender(user.getGender()).age(user.getAge()).refuelingPrice(refuelingPrice).myEcoPrice(ecoPrice)
+                .gender(user.getGender()).age(user.getAge().getAgeBound()).refuelingPrice(refuelingPrice).myEcoPrice(ecoPrice)
                 .averageEcoPrice(average).imageUrl(foodImage.getImageUrl()).rankPercentage(userEcoRecord.getPerRank())
                 .build();
     }

--- a/backend/src/test/java/com/kaspi/backend/controller/UserGasRecordControllerTest.java
+++ b/backend/src/test/java/com/kaspi/backend/controller/UserGasRecordControllerTest.java
@@ -92,7 +92,7 @@ class UserGasRecordControllerTest {
     @DisplayName("사용자 절약 정보 조회 테스트")
     void getUserEcoRecord() throws Exception {
         //User user = new User(1L, "user1", "password", Gender.MALE, Age.FORTY);
-        UserEcoRecordResDto userEcoRecordResDto = UserEcoRecordResDto.builder().userId("user1").gender(Gender.MALE).age(Age.FORTY)
+        UserEcoRecordResDto userEcoRecordResDto = UserEcoRecordResDto.builder().userId("user1").gender(Gender.MALE).age(Age.FORTY.getAgeBound())
                         .myEcoPrice(200).averageEcoPrice(300).refuelingPrice(20000).imageUrl("url").rankPercentage(0.5).build();
         when(userRecordService.calMonthUserEcoPrice()).thenReturn(userEcoRecordResDto);
 

--- a/backend/src/test/java/com/kaspi/backend/service/UserRecordServiceTest.java
+++ b/backend/src/test/java/com/kaspi/backend/service/UserRecordServiceTest.java
@@ -182,7 +182,7 @@ class UserRecordServiceTest {
         // Assert
         assertEquals("user1", result.getUserId());
         assertEquals(Gender.MALE, result.getGender());
-        assertEquals(Age.FORTY, result.getAge());
+        assertEquals(Age.FORTY.getAgeBound(), result.getAge());
         assertEquals(20000, result.getRefuelingPrice());
         assertEquals(200, result.getMyEcoPrice());
         assertEquals(320, result.getAverageEcoPrice());


### PR DESCRIPTION
## 🌿 이슈 번호 : #129 

<br>

## 📝 PR 유형 
- [ ] 새로운 feature 추가
- [x] feature 수정 (기능 업데이트, 버그 수정 등)
- [ ] 관련 문서 추가
- [ ] 관련 문서 수정

<br>

## 🧑‍💻 작업 내용 
- 프론트엔드의 요청으로 response Dto에서 age값을 Age enum의 value 값으로 변경하였습니다

<br>

## ❗️ 리뷰어는 여기에 집중해주세요!   


<br>

## 🏃‍♂️ 다음 작업 계획 


<br>

## 기타 사항 
- 언제든 의논 후 PR template 양식을 수정하고 싶어요.
