### PR TITLE
Feature/ user gas record fix -> dev: 주유기록 입력시 가스품종 예외처리

### DIFF
--- a/backend/src/main/java/com/kaspi/backend/service/GasStationService.java
+++ b/backend/src/main/java/com/kaspi/backend/service/GasStationService.java
@@ -5,6 +5,7 @@ import com.kaspi.backend.domain.GasDetailDto;
 import com.kaspi.backend.domain.GasStation;
 import com.kaspi.backend.domain.GasStationDto;
 import com.kaspi.backend.dto.FindGasStationResDto;
+import com.kaspi.backend.enums.GasBrand;
 import com.kaspi.backend.util.exception.SqlNotFoundException;
 import com.kaspi.backend.util.response.code.ErrorCode;
 import java.util.NoSuchElementException;
@@ -41,7 +42,7 @@ public class GasStationService {
     private void insertMatchingGasStation(GasStation gasStation, List<FindGasStationResDto> matchingGasStations) {
         matchingGasStations.add(FindGasStationResDto.builder()
                 .stationNo(gasStation.getStationNo())
-                .brand(gasStation.getBrand())
+                .brand(GasBrand.getImgByDbName(gasStation.getBrand()))
                 .name(gasStation.getName())
                 .area(gasStation.getArea())
                 .address(gasStation.getAddress())

--- a/backend/src/main/java/com/kaspi/backend/service/UserRecordService.java
+++ b/backend/src/main/java/com/kaspi/backend/service/UserRecordService.java
@@ -46,9 +46,9 @@ public class UserRecordService {
         Optional<Long> todayGasPrice = gasDetailDao.findTodayGasPrice(gasStation.getStationNo(),
                 userGasRecordReqDto.getGasType().name(),
                 GasDetail.getNowDateToStr());//오늘 날짜로 계산
-        if (todayGasPrice.isEmpty()) {
+        if (todayGasPrice.isEmpty()||todayGasPrice.get()==0) {
             log.error("DB에 오늘날짜에 해당되는 주유 가격 정보가 존재하지 않음 가스타입:{}, 주유소PK:{}", userGasRecordReqDto.getGasType().name(), gasStation.getStationNo());
-            throw new NoSuchElementException(ErrorCode.SQL_NOT_FOUND.getMessage());
+            throw new SqlNotFoundException(ErrorCode.SQL_NOT_FOUND);
         }
         Long userGasAmount = (long) Math.round(userGasRecordReqDto.getRefuelingPrice() / todayGasPrice.get());
         log.info("사용자가 주유한 가스타입:{}, 주유량:{}", userGasRecordReqDto.getGasType().name(), userGasAmount);

--- a/backend/src/test/java/com/kaspi/backend/service/GasStationServiceTest.java
+++ b/backend/src/test/java/com/kaspi/backend/service/GasStationServiceTest.java
@@ -3,6 +3,7 @@ package com.kaspi.backend.service;
 import com.kaspi.backend.dao.GasStationDao;
 import com.kaspi.backend.domain.GasStation;
 import com.kaspi.backend.dto.FindGasStationResDto;
+import com.kaspi.backend.enums.GasBrand;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -31,8 +32,8 @@ class GasStationServiceTest {
     void getGasStationByContainingName() {
         //given
         List<GasStation> gasStations = Arrays.asList(
-                GasStation.builder().name("유진 주유소").build(),
-                GasStation.builder().name("서울 유진 주유소").build()
+                GasStation.builder().name("유진 주유소").brand(GasBrand.SK_GAS.getDbName()).build(),
+                GasStation.builder().name("서울 유진 주유소").brand(GasBrand.SK_GAS.getDbName()).build()
         );
         List<FindGasStationResDto> expectedMatchingGasStations = Arrays.asList(
                 FindGasStationResDto.builder().name("유진 주유소").build(),

--- a/backend/src/test/java/com/kaspi/backend/service/UserRecordServiceTest.java
+++ b/backend/src/test/java/com/kaspi/backend/service/UserRecordServiceTest.java
@@ -20,6 +20,7 @@ import com.kaspi.backend.enums.GasBrand;
 import com.kaspi.backend.enums.Age;
 import com.kaspi.backend.enums.GasType;
 
+import com.kaspi.backend.util.exception.SqlNotFoundException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -93,7 +94,7 @@ class UserRecordServiceTest {
                 GasDetail.getNowDateToStr())) // 항상 오늘날짜로 기준
                 .thenReturn(Optional.empty());//가솔린 1L당 1000원
         //when
-        assertThrows(NoSuchElementException.class, () -> {
+        assertThrows(SqlNotFoundException.class, () -> {
             userRecordService.calTodayUserGasAmount(userGasRecordReqDto, gasStation);
         });
 


### PR DESCRIPTION
## 🌿 이슈 번호 : #163 

<br>

## 📝 PR 유형 
- [ ] 새로운 feature 추가
- [x] feature 수정 (기능 업데이트, 버그 수정 등)
- [ ] 관련 문서 추가
- [ ] 관련 문서 수정

<br>

## 🧑‍💻 작업 내용 
- 주유기록 입력시에 해당 주유소가 사용자 요청의 유종을 취급하지 않는경우만 예외처리하고 있었습니다.
- 하지만 실제 DB에서는 해당 유종이 0원인값도 취급하지 않는 경우이기에 예외처리를 추가로 진행하였습니다.
- 주유기록 입력시 주유소 검색에서 brand를 이미지 uri를 주도록 변경하였습니다.

<br>

## ❗️ 리뷰어는 여기에 집중해주세요!   
- 커밋이 적기때문에 서비스로직의 예외처리 부분만 처리하면 될 것 같습니다.

<br>

## 🏃‍♂️ 다음 작업 계획 
- ssl/tls인증 구성

<br>

## 기타 사항 
- 언제든 의논 후 PR template 양식을 수정하고 싶어요.
