### PR TITLE
Feature/#167_gas record month->dev:사용자 월별 주유기록 api

### DIFF
--- a/backend/src/main/java/com/kaspi/backend/controller/UserGasRecordController.java
+++ b/backend/src/main/java/com/kaspi/backend/controller/UserGasRecordController.java
@@ -77,6 +77,12 @@ public class UserGasRecordController {
                 .body(CommonResponseDto.toResponse(DefaultCode.SUCCESS_FIND_USER_ECO_RECORD, userRecordService.calMonthUserEcoPrice()));
     }
 
+    @GetMapping("/user/gas-record/month")
+    public ResponseEntity<CommonResponseDto> getUsersMonthRecord() {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponseDto.toResponse(DefaultCode.SUCCESS_FIND_USER_RECORDS_MONTH, userRecordService.getUsersRecordPerMonth()));
+    }
+
 
        
 }

--- a/backend/src/main/java/com/kaspi/backend/dao/UserGasRecordDao.java
+++ b/backend/src/main/java/com/kaspi/backend/dao/UserGasRecordDao.java
@@ -27,6 +27,10 @@ public interface UserGasRecordDao extends CrudRepository<UserGasRecord, Long> {
             "on u.user_no = ugr.user_no where gender = :gender and age = :age")
     Optional<List<EcoRecord>> findSavingPriceByGenderAndAge(@Param("gender") Gender gender, @Param("age") Age age, @Param("date") LocalDate date);
 
+
+    /**
+     * 사용자의 주유기록에서 월별로 그룹화 하여 해당날짜, 월별 주유 금액, 전국 유가 평균값을 기반으로한 주유금액을 리턴합니다.
+     */
     @Query("SELECT \n"
             + "  DATE_FORMAT(charge_date, '%Y.%m') AS month_date, \n"
             + "  SUM(refueling_price) AS total_refueling_price, \n"

--- a/backend/src/main/java/com/kaspi/backend/dao/UserGasRecordDao.java
+++ b/backend/src/main/java/com/kaspi/backend/dao/UserGasRecordDao.java
@@ -2,7 +2,7 @@ package com.kaspi.backend.dao;
 
 import com.kaspi.backend.domain.EcoRecord;
 import com.kaspi.backend.domain.UserGasRecord;
-import com.kaspi.backend.dto.UserGasRecordMonthDto;
+import com.kaspi.backend.dto.UserGasRecordMonthResDto;
 import com.kaspi.backend.enums.Age;
 import com.kaspi.backend.enums.Gender;
 import io.lettuce.core.dynamic.annotation.Param;
@@ -30,7 +30,7 @@ public interface UserGasRecordDao extends CrudRepository<UserGasRecord, Long> {
     @Query("SELECT \n"
             + "  DATE_FORMAT(charge_date, '%Y.%m') AS month_date, \n"
             + "  SUM(refueling_price) AS total_refueling_price, \n"
-            + "  SUM(saving_price) AS total_saving_price\n"
+            + "  SUM(saving_price)+SUM(refueling_price) AS total_national_avg_price\n"
             + "FROM \n"
             + "  user_gas_record ugr \n"
             + "WHERE \n"
@@ -40,5 +40,5 @@ public interface UserGasRecordDao extends CrudRepository<UserGasRecord, Long> {
             + "  month_date\n"
             + "ORDER BY \n"
             + "  month_date DESC")
-    Optional<List<UserGasRecordMonthDto>> findSumRecordGroupByMonth(@Param("userNo") Long userNo);
+    Optional<List<UserGasRecordMonthResDto>> findSumRecordGroupByMonth(@Param("userNo") Long userNo);
 }

--- a/backend/src/main/java/com/kaspi/backend/dao/UserGasRecordDao.java
+++ b/backend/src/main/java/com/kaspi/backend/dao/UserGasRecordDao.java
@@ -2,6 +2,7 @@ package com.kaspi.backend.dao;
 
 import com.kaspi.backend.domain.EcoRecord;
 import com.kaspi.backend.domain.UserGasRecord;
+import com.kaspi.backend.dto.UserGasRecordMonthDto;
 import com.kaspi.backend.enums.Age;
 import com.kaspi.backend.enums.Gender;
 import io.lettuce.core.dynamic.annotation.Param;
@@ -25,4 +26,19 @@ public interface UserGasRecordDao extends CrudRepository<UserGasRecord, Long> {
             "(select user_no, sum(refueling_price) refueling_price, sum(saving_price) saving_price from user_gas_record ugr where month(charge_date) = month(:date) and year(charge_date) = year(:date) group by user_no) ugr " +
             "on u.user_no = ugr.user_no where gender = :gender and age = :age")
     Optional<List<EcoRecord>> findSavingPriceByGenderAndAge(@Param("gender") Gender gender, @Param("age") Age age, @Param("date") LocalDate date);
+
+    @Query("SELECT \n"
+            + "  DATE_FORMAT(charge_date, '%Y.%m') AS month_date, \n"
+            + "  SUM(refueling_price) AS total_refueling_price, \n"
+            + "  SUM(saving_price) AS total_saving_price\n"
+            + "FROM \n"
+            + "  user_gas_record ugr \n"
+            + "WHERE \n"
+            + "  charge_date BETWEEN DATE_SUB(NOW(), INTERVAL 12 MONTH) AND NOW()\n"
+            + "  AND user_no = :userNo\n"
+            + "GROUP BY \n"
+            + "  month_date\n"
+            + "ORDER BY \n"
+            + "  month_date DESC")
+    Optional<List<UserGasRecordMonthDto>> findSumRecordGroupByMonth(@Param("userNo") Long userNo);
 }

--- a/backend/src/main/java/com/kaspi/backend/dto/UserGasRecordMonthDto.java
+++ b/backend/src/main/java/com/kaspi/backend/dto/UserGasRecordMonthDto.java
@@ -1,0 +1,11 @@
+package com.kaspi.backend.dto;
+
+import lombok.Getter;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Getter
+public class UserGasRecordMonthDto {
+    private String monthDate;
+    private Long totalRefuelingPrice;
+    private Long totalSavingPrice;
+}

--- a/backend/src/main/java/com/kaspi/backend/dto/UserGasRecordMonthResDto.java
+++ b/backend/src/main/java/com/kaspi/backend/dto/UserGasRecordMonthResDto.java
@@ -1,11 +1,10 @@
 package com.kaspi.backend.dto;
 
 import lombok.Getter;
-import org.springframework.web.bind.annotation.GetMapping;
 
 @Getter
-public class UserGasRecordMonthDto {
+public class UserGasRecordMonthResDto {
     private String monthDate;
     private Long totalRefuelingPrice;
-    private Long totalSavingPrice;
+    private Long totalNationalAvgPrice;
 }

--- a/backend/src/main/java/com/kaspi/backend/dto/UserGasRecordMonthResDto.java
+++ b/backend/src/main/java/com/kaspi/backend/dto/UserGasRecordMonthResDto.java
@@ -1,8 +1,10 @@
 package com.kaspi.backend.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class UserGasRecordMonthResDto {
     private String monthDate;
     private Long totalRefuelingPrice;

--- a/backend/src/main/java/com/kaspi/backend/service/UserRecordService.java
+++ b/backend/src/main/java/com/kaspi/backend/service/UserRecordService.java
@@ -6,6 +6,7 @@ import com.kaspi.backend.dao.GasStationDao;
 import com.kaspi.backend.dao.UserGasRecordDao;
 import com.kaspi.backend.domain.*;
 import com.kaspi.backend.dto.UserEcoRecordResDto;
+import com.kaspi.backend.dto.UserGasRecordMonthResDto;
 import com.kaspi.backend.dto.UserGasRecordReqDto;
 import com.kaspi.backend.dto.UserGasRecordResDto;
 import com.kaspi.backend.util.exception.SqlNotFoundException;
@@ -13,14 +14,9 @@ import com.kaspi.backend.util.response.code.ErrorCode;
 
 import java.time.LocalDate;
 import java.util.*;
-import com.kaspi.backend.util.exception.SqlNotFoundException;
-import com.kaspi.backend.util.response.code.ErrorCode;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.util.Date;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
@@ -133,6 +129,24 @@ public class UserRecordService {
     private long getAverage(List<EcoRecord> rankSavingPrices) {
         double totalSavingPrice = rankSavingPrices.stream().mapToDouble(EcoRecord::getSavingPrice).sum();
         return (long) (totalSavingPrice / rankSavingPrices.size());
+    }
+
+
+    /**
+     * 사용자의 월별 주유금액/ 전국 유가 평균값의 주유금액 비교 로직 값 들고오기
+     */
+    public List<UserGasRecordMonthResDto> getUsersRecordPerMonth() {
+        User user = httpSessionService.getUserFromSession();
+        Optional<List<UserGasRecordMonthResDto>> sumRecordGroupByMonth = userGasRecordDao.findSumRecordGroupByMonth(user.getUserNo());
+        checkUserRecordPerMonth(user, sumRecordGroupByMonth);
+        return sumRecordGroupByMonth.get();
+    }
+
+    private void checkUserRecordPerMonth(User user, Optional<List<UserGasRecordMonthResDto>> sumRecordGroupByMonth) {
+        if(sumRecordGroupByMonth.isEmpty()){
+            log.debug("사용자의 월별 주유기록 부분에서 sql쿼리문에서 문제가 생겼습니다. 사용자 PK:{}", user.getUserNo());
+            throw new SqlNotFoundException(ErrorCode.SQL_NOT_FOUND);
+        }
     }
 
 }

--- a/backend/src/main/java/com/kaspi/backend/util/response/code/DefaultCode.java
+++ b/backend/src/main/java/com/kaspi/backend/util/response/code/DefaultCode.java
@@ -9,6 +9,7 @@ public enum DefaultCode implements Code {
     SAVE_USER_GAS_RECORD("M002", "유저의 주유데이터 저장 성공"),
     GET_USER_GAS_RECORDS("M003", "유저의 주유데이터 조회 성공"),
     SUCCESS_FIND_USER_ECO_RECORD("M004", "유저의 절약 금액 조회 성공"),
+    SUCCESS_FIND_USER_RECORDS_MONTH("M005", "유저의 주유기록 월별비교 데이터 조회 성공"),
     SUCCESS_TO_FIND_GAS_DETAIL("G001", "주유소 가격 상세정보를 찾았습니다.");
 
     private String code;

--- a/backend/src/test/java/com/kaspi/backend/controller/UserGasRecordControllerTest.java
+++ b/backend/src/test/java/com/kaspi/backend/controller/UserGasRecordControllerTest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kaspi.backend.domain.GasStation;
 import com.kaspi.backend.dto.UserEcoRecordResDto;
+import com.kaspi.backend.dto.UserGasRecordMonthResDto;
 import com.kaspi.backend.dto.UserGasRecordReqDto;
 import com.kaspi.backend.dto.UserGasRecordResDto;
 import com.kaspi.backend.enums.GasBrand;
@@ -22,6 +23,7 @@ import com.kaspi.backend.service.UserRecordService;
 import com.kaspi.backend.util.config.TestRedisConfiguration;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import com.kaspi.backend.util.response.code.DefaultCode;
 import org.junit.jupiter.api.DisplayName;
@@ -147,5 +149,25 @@ class UserGasRecordControllerTest {
                 .andExpect(jsonPath("$.data.userId").value(userEcoRecordResDto.getUserId()))
                 .andExpect(jsonPath("$.data.gender").value(Gender.MALE.name()))
                 .andExpect(jsonPath("$.data.myEcoPrice").value(userEcoRecordResDto.getMyEcoPrice()));
+    }
+
+    @Test
+    @DisplayName("사용자 월별비교 api")
+    void getUsersMonthRecord() throws Exception {
+        //given
+        List<UserGasRecordMonthResDto> recordList = Collections.singletonList(UserGasRecordMonthResDto.builder()
+                .monthDate("2023.02")
+                .totalRefuelingPrice(1000L)
+                .totalNationalAvgPrice(1220L).build());
+        when(userRecordService.getUsersRecordPerMonth()).thenReturn(recordList);
+        // Act and Assert
+        mockMvc.perform(get("/api/v2/user/gas-record/month")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(DefaultCode.SUCCESS_FIND_USER_RECORDS_MONTH.getCode()))
+                .andExpect(jsonPath("$.message").value(DefaultCode.SUCCESS_FIND_USER_RECORDS_MONTH.getMessage()))
+                .andExpect(jsonPath("$.data[0].monthDate").value(recordList.get(0).getMonthDate()))
+                .andExpect(jsonPath("$.data[0].totalRefuelingPrice").value(recordList.get(0).getTotalRefuelingPrice()))
+                .andExpect(jsonPath("$.data[0].totalNationalAvgPrice").value(recordList.get(0).getTotalNationalAvgPrice()));
     }
 }

--- a/backend/src/test/java/com/kaspi/backend/dao/UserGasRecordDaoTest.java
+++ b/backend/src/test/java/com/kaspi/backend/dao/UserGasRecordDaoTest.java
@@ -3,20 +3,15 @@ package com.kaspi.backend.dao;
 import com.kaspi.backend.domain.GasStation;
 import com.kaspi.backend.domain.User;
 import com.kaspi.backend.domain.UserGasRecord;
-import com.kaspi.backend.dto.UserGasRecordMonthDto;
+import com.kaspi.backend.dto.UserGasRecordMonthResDto;
 import com.kaspi.backend.enums.Age;
 import com.kaspi.backend.enums.GasType;
 import com.kaspi.backend.enums.Gender;
 import com.kaspi.backend.util.config.TestRedisConfiguration;
 import java.time.LocalDate;
 import com.kaspi.backend.domain.EcoRecord;
-import com.kaspi.backend.domain.UserGasRecord;
-import com.kaspi.backend.enums.Age;
-import com.kaspi.backend.enums.Gender;
-import com.kaspi.backend.util.config.TestRedisConfiguration;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,12 +24,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
-import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
 
 @DataJdbcTest
@@ -119,15 +110,15 @@ class UserGasRecordDaoTest {
         User savedUser = userDao.save(user);
         saveUserRecordPerMonth(savedUser);
         //when
-        Optional<List<UserGasRecordMonthDto>> sumRecordGroupByMonth = userGasRecordDao.findSumRecordGroupByMonth(
+        Optional<List<UserGasRecordMonthResDto>> sumRecordGroupByMonth = userGasRecordDao.findSumRecordGroupByMonth(
                 user.getUserNo());
         //then
-        List<UserGasRecordMonthDto> userGasRecordMonthDtos = sumRecordGroupByMonth.get();
+        List<UserGasRecordMonthResDto> userGasRecordMonthResDtos = sumRecordGroupByMonth.get();
         for (int i = 0; i < 12; i++) {
-            assertThat(userGasRecordMonthDtos.get(i).getMonthDate()).isEqualTo(LocalDate.now().minusMonths(i).format(
+            assertThat(userGasRecordMonthResDtos.get(i).getMonthDate()).isEqualTo(LocalDate.now().minusMonths(i).format(
                     DateTimeFormatter.ofPattern("yyyy.MM")));
-            assertThat(userGasRecordMonthDtos.get(i).getTotalRefuelingPrice()).isEqualTo((i * 1000));
-            assertThat(userGasRecordMonthDtos.get(i).getTotalSavingPrice()).isEqualTo((i * 10));
+            assertThat(userGasRecordMonthResDtos.get(i).getTotalRefuelingPrice()).isEqualTo((i * 1000));
+            assertThat(userGasRecordMonthResDtos.get(i).getTotalNationalAvgPrice()).isEqualTo((i * 10)+(i * 1000));
         }
     }
 

--- a/backend/src/test/java/com/kaspi/backend/dao/UserGasRecordDaoTest.java
+++ b/backend/src/test/java/com/kaspi/backend/dao/UserGasRecordDaoTest.java
@@ -3,6 +3,7 @@ package com.kaspi.backend.dao;
 import com.kaspi.backend.domain.GasStation;
 import com.kaspi.backend.domain.User;
 import com.kaspi.backend.domain.UserGasRecord;
+import com.kaspi.backend.dto.UserGasRecordMonthDto;
 import com.kaspi.backend.enums.Age;
 import com.kaspi.backend.enums.GasType;
 import com.kaspi.backend.enums.Gender;
@@ -13,6 +14,8 @@ import com.kaspi.backend.domain.UserGasRecord;
 import com.kaspi.backend.enums.Age;
 import com.kaspi.backend.enums.Gender;
 import com.kaspi.backend.util.config.TestRedisConfiguration;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
@@ -26,8 +29,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -83,10 +88,12 @@ class UserGasRecordDaoTest {
         assertThat(actualGasRecord.getRefuelingPrice()).isEqualTo(savedUserGasRecord.getRefuelingPrice());
         assertThat(actualGasRecord.getSavingPrice()).isEqualTo(savedUserGasRecord.getSavingPrice());
     }
+
     @Test
     @DisplayName("현재 날짜가 해당된 달의 유저가스레코드를 가져오는 성공 테스트")
     void findByMonthOfNow_SUCCESS() {
-        Optional<List<UserGasRecord>> optionalUserGasRecordList = userGasRecordDao.findByMonthOfNow(1L, LocalDate.now());
+        Optional<List<UserGasRecord>> optionalUserGasRecordList = userGasRecordDao.findByMonthOfNow(1L,
+                LocalDate.now());
         SoftAssertions softly = new SoftAssertions();
         for (UserGasRecord userGasRecord : optionalUserGasRecordList.get()) {
             //2월 안에 드는지 테스트
@@ -98,9 +105,45 @@ class UserGasRecordDaoTest {
     @Test
     @DisplayName("유저 절약 정보 조회 테스트")
     void findSavingPriceByGenderAndAge_SUCCESS() {
-        List<EcoRecord> ecoRecords = userGasRecordDao.findSavingPriceByGenderAndAge(Gender.MALE, Age.FORTY, LocalDate.now()).get();
-        Assertions.assertThat(ecoRecords.size()).isEqualTo(1);
+        List<EcoRecord> ecoRecords = userGasRecordDao.findSavingPriceByGenderAndAge(Gender.MALE, Age.FORTY,
+                LocalDate.now()).get();
+        assertThat(ecoRecords.size()).isEqualTo(1);
 
     }
 
+    @Test
+    @DisplayName("주유기록 월별 합계(주유금액, 국내 평균 주유금액)")
+    void findSumRecordGroupByMonth() {
+        //given
+        User user = User.builder().id("test").password("test").age(Age.TWENTY).gender(Gender.MALE).build();
+        User savedUser = userDao.save(user);
+        saveUserRecordPerMonth(savedUser);
+        //when
+        Optional<List<UserGasRecordMonthDto>> sumRecordGroupByMonth = userGasRecordDao.findSumRecordGroupByMonth(
+                user.getUserNo());
+        //then
+        List<UserGasRecordMonthDto> userGasRecordMonthDtos = sumRecordGroupByMonth.get();
+        for (int i = 0; i < 12; i++) {
+            assertThat(userGasRecordMonthDtos.get(i).getMonthDate()).isEqualTo(LocalDate.now().minusMonths(i).format(
+                    DateTimeFormatter.ofPattern("yyyy.MM")));
+            assertThat(userGasRecordMonthDtos.get(i).getTotalRefuelingPrice()).isEqualTo((i * 1000));
+            assertThat(userGasRecordMonthDtos.get(i).getTotalSavingPrice()).isEqualTo((i * 10));
+        }
+    }
+
+    private void saveUserRecordPerMonth(User user) {
+        List<UserGasRecord> userGasRecordList = new ArrayList<>();
+        for (int i = 0; i < 12; i++) {
+            userGasRecordList.add(
+                    UserGasRecord.builder()
+                            .userNo(user.getUserNo())
+                            .gasStationNo(1L)
+                            .recordGasType(GasType.GASOLINE)
+                            .recordGasAmount(10L)
+                            .chargeDate(LocalDate.now().minusMonths(i))
+                            .refuelingPrice((long) (i * 1000))
+                            .savingPrice((long) (i * 10)).build());
+        }
+        userGasRecordDao.saveAll(userGasRecordList);
+    }
 }


### PR DESCRIPTION
## 🌿 이슈 번호 : #167 

<br>

## 📝 PR 유형 
- [x] 새로운 feature 추가
- [ ] feature 수정 (기능 업데이트, 버그 수정 등)
- [ ] 관련 문서 추가
- [ ] 관련 문서 수정

<br>

## 🧑‍💻 작업 내용 
- 사용자 월별 주유기록 api를 구축하였습니다.
- 리턴되는값은 
<img width="333" alt="스크린샷 2023-02-15 오후 10 21 05" src="https://user-images.githubusercontent.com/87477702/219038809-00508480-9481-492b-8bff-c873528109d3.png">
다음과 같이 각 월별 사용자가 총 주유한 금액/만약 해당 주유날짜에 유가평균으로 주유한경우 예상금액 이렇게 데이터가 보여집니다.

<br>

## ❗️ 리뷰어는 여기에 집중해주세요!   
- 처음에는 자바 로직으로 구성을 하려다 sql쿼리문으로 작성을 해보았습니다. 어떤것이 더 나은지 이야기해주시면 감사하겠습니다.

<br>

## 🏃‍♂️ 다음 작업 계획 
- 드디어 해치웠나?...
- 로그아웃, 회원정보 수정 및 삭제, 필터 인터셉터 변경

<br>

## 기타 사항 
- 언제든 의논 후 PR template 양식을 수정하고 싶어요.
