### PR TITLE
feature/171 csv modify -> dev: 오피넷 csv 파일 가공 메소드 추가 및 DB 데이터 삽입

### DIFF
--- a/util/src/main/java/org/example/dao/GasStationDao.java
+++ b/util/src/main/java/org/example/dao/GasStationDao.java
@@ -6,10 +6,14 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 @Repository
 public interface GasStationDao extends CrudRepository<GasStation, Long> {
 
     @Query("select * from gas_station where address like :address and brand = :brand")
     public Optional<GasStation> findByAddressAndBrand(@Param("address") String address, @Param("brand") String brand);
+
+    @Query("select * from gas_station")
+    Optional<List<GasStation>> findAllGasStation();
 }

--- a/util/src/main/java/org/example/domain/GasDetail.java
+++ b/util/src/main/java/org/example/domain/GasDetail.java
@@ -34,6 +34,7 @@ public class GasDetail {
         this.gasType = gasType;
         this.date = date;
     }
+
     public static List<GasDetail> parseListGasDetail(GasStation gasStation, String[] attribute) {
         List<GasDetail> list = new ArrayList<>();
         list.add(new GasDetail(gasStation, Integer.valueOf(attribute[AttributeIndex.PREMIUM_GASOLINE.getIndex()]), GasType.PREMIUM_GASOLINE, LocalDate.parse(attribute[AttributeIndex.DATE.getIndex()], DateTimeFormatter.ofPattern("yyyyMMdd"))));
@@ -41,6 +42,7 @@ public class GasDetail {
         list.add(new GasDetail(gasStation, Integer.valueOf(attribute[AttributeIndex.DIESEL.getIndex()]), GasType.DIESEL, LocalDate.parse(attribute[AttributeIndex.DATE.getIndex()], DateTimeFormatter.ofPattern("yyyyMMdd"))));
         return list;
     }
+
     public static List<GasDetail> parseListGasDetail(GasStation gasStation, String[] attribute, LocalDate date) {
         List<GasDetail> list = new ArrayList<>();
         list.add(new GasDetail(gasStation, Integer.valueOf(attribute[SchedulerIndex.PREMIUM_GASOLINE.getIndex()]), GasType.PREMIUM_GASOLINE, date));
@@ -52,6 +54,7 @@ public class GasDetail {
     public static GasDetail parseLpgGasDetail(GasStation gasStation, String[] attribute) {
         return new GasDetail(gasStation, Integer.valueOf(attribute[AttributeIndex.LPG.getIndex()]), GasType.LPG, LocalDate.parse(attribute[AttributeIndex.DATE.getIndex()], DateTimeFormatter.ofPattern("yyyyMMdd")));
     }
+
     public static GasDetail parseLpgGasDetail(GasStation gasStation, String[] attribute, LocalDate date) {
         return new GasDetail(gasStation, Integer.valueOf(attribute[SchedulerIndex.LPG.getIndex()]), GasType.LPG, date);
     }

--- a/util/src/main/java/org/example/domain/GasStation.java
+++ b/util/src/main/java/org/example/domain/GasStation.java
@@ -6,6 +6,9 @@ import org.example.enums.SchedulerIndex;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
+
+import java.util.Objects;
+
 @Getter
 @Table("gas_station")
 public class GasStation {
@@ -47,6 +50,19 @@ public class GasStation {
             return true;
         }
         return false;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GasStation that = (GasStation) o;
+        return Objects.equals(address, that.address) && Objects.equals(brand, that.brand);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(address, brand);
     }
 }
 

--- a/util/src/test/java/org/example/dao/GasStationDaoTest.java
+++ b/util/src/test/java/org/example/dao/GasStationDaoTest.java
@@ -1,0 +1,28 @@
+package org.example.dao;
+
+import org.assertj.core.api.Assertions;
+import org.example.domain.GasStation;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+@DataJdbcTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class GasStationDaoTest {
+
+    @Autowired
+    GasStationDao gasStationDao;
+    @Test
+    @DisplayName("selectAll 성공 테스트")
+    void selectAll() {
+        List<GasStation> gasStations = gasStationDao.findAllGasStation().orElseThrow(() -> new RuntimeException());
+        Assertions.assertThat(gasStations.size()).isEqualTo(1);
+        //항상 성공하게 하려면 어떻게 해야할까..?
+    }
+
+}

--- a/util/src/test/java/org/example/service/FileUploadServiceTest.java
+++ b/util/src/test/java/org/example/service/FileUploadServiceTest.java
@@ -3,8 +3,11 @@ package org.example.service;
 import org.example.service.fileupload.FileUploadService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.devtools.v85.io.IO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.IOException;
 
 @SpringBootTest
 class FileUploadServiceTest {
@@ -21,7 +24,7 @@ class FileUploadServiceTest {
 
     @Test
     @DisplayName("fileopen 테스트")
-    void test2() {
+    void test2() throws IOException {
         fileUploadService.fileOpen();
     }
 }


### PR DESCRIPTION
## 🌿 이슈 번호 : #171 

<br>

## 📝 PR 유형 
- [x] 새로운 feature 추가
- [x] feature 수정 (기능 업데이트, 버그 수정 등)
- [ ] 관련 문서 추가
- [ ] 관련 문서 수정

<br>

## 🧑‍💻 작업 내용 
- 기존 csv 파일을 한줄씩 분석해서 원격지로 쿼리하나씩 commit 하던 코드를 아래와 같이 개선하였습니다.
- 오피넷의 csv 파일을 gas_detail 테이블에 맞는 csv 파일로 변경하도록 기능을 추가하였습니다.
- <img width="479" alt="image" src="https://user-images.githubusercontent.com/35219960/219072976-d83903aa-13a3-4b19-b9db-d805abec7dc7.png">

- 로컬 pc에 생성된 new.csv 파일을 서버로 전송하고 docker cp 명령어를 통해 mysql 컨테이너로 복사하였습니다.
- Load data local infile 명령어를 통해 csv 파일을 mysql의 테이블에 삽입하였습니다.
- 기존 100만개 정도의 데이터를 보낼때 12시간 12분정도가 걸렸는데, 50만개 데이터를 전송하는데 약 10초 정도로 성능을 개선하였습니다.

<br>

## ❗️ 리뷰어는 여기에 집중해주세요!   
- 해당 메소드는 test 코드에서 실행하여 local에 csv 파일을 생성합니다.
- 따라서 서비스로직과는 관련없는 오직 csv 파일을 자동적으로 만들기 위한 코드이므로 하드코딩된 것들이 많습니다.
- 프론트엔드와 서비스 테스트를 위해 데이터가 빨리 필요한 상황이였으므로 빠른 구현을 목표로 코딩되어 코드의 품질이 조금 떨어지는 점 양해부탁 드립니다.

<br>

## 🏃‍♂️ 다음 작업 계획 
- 1일 유가 다운로드 벌크 or 배치 작업

<br>

## 기타 사항 
- 언제든 의논 후 PR template 양식을 수정하고 싶어요.
