### PR TITLE
Feature/186 month api order by asc -> dev: 한달 주유소 상세정보 날짜 오름차순 정렬

### DIFF
--- a/backend/src/main/java/com/kaspi/backend/dao/GasDetailDao.java
+++ b/backend/src/main/java/com/kaspi/backend/dao/GasDetailDao.java
@@ -21,6 +21,6 @@ public interface GasDetailDao extends CrudRepository<GasDetail, Long> {
     @Query("select * from gas_detail where station_no = :stationNo and created_date = :date")
     Optional<List<GasDetail>> findByStationNoAndDate(@Param("stationNo") Long stationNo, @Param("date") LocalDate date);
 
-    @Query("select * from gas_detail where station_no = :stationNo and created_date >= date_add( :date, interval -1 month)")
+    @Query("select * from gas_detail where station_no = :stationNo and created_date >= date_add( :date, interval -1 month) order by created_date")
     Optional<List<GasDetail>> findByStationAndOneMonth(@Param("stationNo") Long stationNo, @Param("date") LocalDate date);
 }

--- a/backend/src/test/java/com/kaspi/backend/dao/GasDetailDaoTest.java
+++ b/backend/src/test/java/com/kaspi/backend/dao/GasDetailDaoTest.java
@@ -4,6 +4,7 @@ import com.kaspi.backend.domain.GasDetail;
 import com.kaspi.backend.domain.GasStation;
 import com.kaspi.backend.util.config.TestRedisConfiguration;
 import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -14,8 +15,11 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
 
 @DataJdbcTest
 @ContextConfiguration(classes = {TestRedisConfiguration.class})
@@ -77,5 +81,18 @@ class GasDetailDaoTest {
             softAssertions.assertThat(gasDetail.getDate()).isBetween(LocalDate.now().minusMonths(1), LocalDate.now());
         }
         softAssertions.assertAll();
+    }
+    @Test
+    @DisplayName("1달 주유소 정보 날짜 오름차순 정렬 테스트")
+    void findByStationAndOneMonth_asc() {
+        //given
+        LocalDate date = LocalDate.of(2023, 2, 12);
+
+        Optional<GasStation> optionalGasStation = gasStationDao.findByAddressAndBrand("평창문화로 135", "현대오일뱅크");
+        GasStation gasStation = optionalGasStation.get();
+        Optional<List<GasDetail>> optionalGasDetails = gasDetailDao.findByStationAndOneMonth(gasStation.getStationNo(), date);
+        List<GasDetail> gasDetails = optionalGasDetails.get();
+
+        assertThat(gasDetails).isSortedAccordingTo(Comparator.comparing(GasDetail::getDate));
     }
 }


### PR DESCRIPTION
## 🌿 이슈 번호 : #186 

<br>

## 📝 PR 유형 
- [ ] 새로운 feature 추가
- [x] feature 수정 (기능 업데이트, 버그 수정 등)
- [ ] 관련 문서 추가
- [ ] 관련 문서 수정

<br>

## 🧑‍💻 작업 내용 
- 한달 주유소 상세정보를 날짜 오름차순으로 정렬하였습니다

<br>

## ❗️ 리뷰어는 여기에 집중해주세요!   
- 오름차순 정렬 테스트에 대해 참고해주세요! 나중에 사용해보세요

