### PR TITLE
#221 fix: 주유소 브랜드 uri 변경

### DIFF
--- a/backend/src/main/java/com/kaspi/backend/dto/FindGasStationResDto.java
+++ b/backend/src/main/java/com/kaspi/backend/dto/FindGasStationResDto.java
@@ -36,6 +36,10 @@ public class FindGasStationResDto implements Serializable {
                 .build();
     }
 
+    public void updateBrandToImage() {
+        this.brand = GasBrand.getImgByDbName(this.brand);
+    }
+
     @Override
     public boolean equals(Object o) {
         FindGasStationResDto opposite = (FindGasStationResDto) o;

--- a/backend/src/main/java/com/kaspi/backend/service/GasStationService.java
+++ b/backend/src/main/java/com/kaspi/backend/service/GasStationService.java
@@ -30,9 +30,16 @@ public class GasStationService {
 
     public List<FindGasStationResDto> getGasStationByContainingName(String reqGasStationName, GasType requestGasType) {
         log.info("주유소 이름 검색 요청 name:{}, gasType:{}", reqGasStationName,requestGasType);
-        return gasStationDao.findGastationForGasSearch(getLikeGasStationName(reqGasStationName),requestGasType.name());
+        List<FindGasStationResDto> gasStationForGasSearch = gasStationDao.findGastationForGasSearch(getLikeGasStationName(reqGasStationName), requestGasType.name());
+        updateBrandToUri(gasStationForGasSearch);
+        return gasStationForGasSearch;
     }
 
+    private  void updateBrandToUri(List<FindGasStationResDto> gasStationForGasSearch) {
+        for (FindGasStationResDto stationForGasSearch : gasStationForGasSearch) {
+            stationForGasSearch.updateBrandToImage();
+        }
+    }
 
 
     public GasStation getGasStationByNo(Long gasStationNo) {

--- a/backend/src/test/java/com/kaspi/backend/dto/FindGasStationResDtoTest.java
+++ b/backend/src/test/java/com/kaspi/backend/dto/FindGasStationResDtoTest.java
@@ -44,4 +44,15 @@ class FindGasStationResDtoTest {
         //then
         Assertions.assertThat(list.contains(opposite)).isTrue();
     }
+
+    @Test
+    @DisplayName("가스 브랜드 uri로 변경")
+    void updateBrandToImage() {
+        //given
+        FindGasStationResDto findGasStationResDto = FindGasStationResDto.builder().brand(GasBrand.SK_GAS.getDbName()).build();
+        //when
+        findGasStationResDto.updateBrandToImage();
+        //then
+        Assertions.assertThat(findGasStationResDto.getBrand()).isEqualTo(GasBrand.getImgByDbName(GasBrand.SK_GAS.getDbName()));
+    }
 }

--- a/backend/src/test/java/com/kaspi/backend/service/GasStationServiceTest.java
+++ b/backend/src/test/java/com/kaspi/backend/service/GasStationServiceTest.java
@@ -34,8 +34,8 @@ class GasStationServiceTest {
     void getGasStationByContainingName() {
         //given
         List<FindGasStationResDto> expectedMatchingGasStations = Arrays.asList(
-                FindGasStationResDto.builder().name("유진 주유소").build(),
-                FindGasStationResDto.builder().name("서울 유진 주유소").build()
+                FindGasStationResDto.builder().name("유진 주유소").brand(GasBrand.SK_GAS.getDbName()).build(),
+                FindGasStationResDto.builder().name("서울 유진 주유소").brand(GasBrand.SK_GAS.getDbName()).build()
         );
         String requestGasStation = "유진";
         when(gasStationDao.findGastationForGasSearch("%"+requestGasStation+"%", GasType.GASOLINE.name())).thenReturn(expectedMatchingGasStations);


### PR DESCRIPTION
## 🌿 이슈 번호 : #221 

<br>

## 📝 PR 유형 
- [ ] 새로운 feature 추가
- [x] feature 수정 (기능 업데이트, 버그 수정 등)
- [ ] 관련 문서 추가
- [ ] 관련 문서 수정

<br>

## 🧑‍💻 작업 내용 
- 현재 주유기록 입력시 주유소 검색시 brandimg(uri)가 보이지 않는 오류를 수정하였습니다.

<br>

## ❗️ 리뷰어는 여기에 집중해주세요!   
- 템플릿 오타가 없는지 확인해주세요.

<br>

## 🏃‍♂️ 다음 작업 계획 


<br>

## 기타 사항 
- 언제든 의논 후 PR template 양식을 수정하고 싶어요.